### PR TITLE
Add GH Action for per-PR preview deployments

### DIFF
--- a/.github/workflows/ci-finalize.yml
+++ b/.github/workflows/ci-finalize.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Finalize PR comment
-        # uses: LocalStack/setup-localstack/finish@0.1.2
+        # uses: LocalStack/setup-localstack/finish@main
         uses: LocalStack/setup-localstack/finish@pr-preview
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-finalize.yml
+++ b/.github/workflows/ci-finalize.yml
@@ -11,8 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Finalize PR comment
-        # uses: LocalStack/setup-localstack/finish@main
-        uses: LocalStack/setup-localstack/finish@pr-preview
+        uses: LocalStack/setup-localstack/finish@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           include-preview: true

--- a/.github/workflows/ci-finalize.yml
+++ b/.github/workflows/ci-finalize.yml
@@ -1,4 +1,4 @@
-name: Create PR Preview
+name: Finalize PR Preview
 
 on:
   workflow_run:

--- a/.github/workflows/ci-finalize.yml
+++ b/.github/workflows/ci-finalize.yml
@@ -1,0 +1,18 @@
+name: Create PR Preview
+
+on:
+  workflow_run:
+    workflows: ["Create PR Preview"]
+    types:
+      - completed
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finalize PR comment
+        # uses: LocalStack/setup-localstack/finish@0.1.2
+        uses: LocalStack/setup-localstack/finish@pr-preview
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          include-preview: true

--- a/.github/workflows/ci-preview.yml
+++ b/.github/workflows/ci-preview.yml
@@ -28,5 +28,6 @@ jobs:
             php artisan key:generate
             npm run serverless -- deploy --stage dev
 
-            apiId=$(awslocal apigatewayv2 get-apis| jq -r '.Items[0].ApiEndpoint')
-            echo "Upen URL: $AWS_ENDPOINT_URL/restapis/$apiId/dev/_user_request_/"
+            pip install awscli-local[ver1]
+            apiId=$(awslocal apigatewayv2 get-apis| jq -r '.Items[0].ApiId')
+            echo "Open URL: $AWS_ENDPOINT_URL/restapis/$apiId/dev/_user_request_/"

--- a/.github/workflows/ci-preview.yml
+++ b/.github/workflows/ci-preview.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Deploy Preview
-        # uses: LocalStack/setup-localstack@v0.1.2
+        # uses: LocalStack/setup-localstack@main
         uses: LocalStack/setup-localstack/preview@pr-preview
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-preview.yml
+++ b/.github/workflows/ci-preview.yml
@@ -13,8 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Deploy Preview
-        # uses: LocalStack/setup-localstack@main
-        uses: LocalStack/setup-localstack/preview@pr-preview
+        uses: LocalStack/setup-localstack/preview@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           localstack-api-key: ${{ secrets.LOCALSTACK_API_KEY }}

--- a/.github/workflows/ci-preview.yml
+++ b/.github/workflows/ci-preview.yml
@@ -1,0 +1,32 @@
+name: Create PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy Preview
+        # uses: LocalStack/setup-localstack@v0.1.2
+        uses: LocalStack/setup-localstack/preview@pr-preview
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          localstack-api-key: ${{ secrets.LOCALSTACK_API_KEY }}
+          preview-cmd: |
+            export AWS_DEFAULT_REGION=us-east-1
+
+            npm install --include=dev
+            npm run build
+            composer require bref/bref
+            mv .env.example .env
+            php artisan key:generate
+            npm run serverless -- deploy --stage dev
+
+            apiId=$(awslocal apigatewayv2 get-apis| jq -r '.Items[0].ApiEndpoint')
+            echo "Upen URL: $AWS_ENDPOINT_URL/restapis/$apiId/dev/_user_request_/"

--- a/composer.lock
+++ b/composer.lock
@@ -8988,5 +8988,5 @@
         "php": "^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "vite build"
+        "build": "vite build",
+        "serverless": "serverless"
     },
     "devDependencies": {
         "axios": "^1.1.2",
         "laravel-vite-plugin": "^0.8.0",
-        "serverless-localstack": "^1.1.1",
+        "serverless": "^3.0.0",
+        "serverless-localstack": "^1.1.2",
         "vite": "^4.0.0"
     }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -48,7 +48,7 @@ custom:
         stages:
             # list of stages for which the plugin should be enabled
             - dev
-        autostart: true  # optional - Start LocalStack in Docker on Serverless deploy
-        lambda:
-            # Enable this flag to improve performance
-            mountCode: True
+        # autostart: true  # optional - Start LocalStack in Docker on Serverless deploy
+        # lambda:
+        #     # Enable this flag to improve performance
+        #     mountCode: True


### PR DESCRIPTION
This PR adds a simple GH Action configuration to enable per-PR preview deployments. Only a first step - work in progress..

Note that this requires `LOCALSTACK_API_KEY` to be configured as a secret in the Github Actions settings of this repo. @mnapoli @lukqw 